### PR TITLE
Bugfixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ from src.algos.rnd import train as train_rnd
 from src.algos.cbet import train as train_cbet
 from src.algos.ride import train as train_ride
 
+import torch.multiprocessing
+torch.multiprocessing.set_sharing_strategy('file_system')
+
 def main(flags):
     if flags.model == 'vanilla':
         train_vanilla(flags)

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ from src.algos.rnd import train as train_rnd
 from src.algos.cbet import train as train_cbet
 from src.algos.ride import train as train_ride
 
-
 def main(flags):
     if flags.model == 'vanilla':
         train_vanilla(flags)

--- a/main.py
+++ b/main.py
@@ -7,8 +7,6 @@ from src.algos.rnd import train as train_rnd
 from src.algos.cbet import train as train_cbet
 from src.algos.ride import train as train_ride
 
-import torch.multiprocessing
-torch.multiprocessing.set_sharing_strategy('file_system')
 
 def main(flags):
     if flags.model == 'vanilla':

--- a/src/env_utils.py
+++ b/src/env_utils.py
@@ -443,6 +443,7 @@ class EnvironmentHabitat:
             self.episode_return = torch.zeros(1, 1)
             self.episode_step = torch.zeros(1, 1, dtype=torch.int32)
 
+            os.makedirs(pathlib.Path(self.namefile).parent.absolute(), exist_ok=True)
             with open(self.namefile, 'wb') as handle:
                 pickle.dump(self.true_state_count, handle, protocol=pickle.HIGHEST_PROTOCOL)
 

--- a/src/init_models_and_states.py
+++ b/src/init_models_and_states.py
@@ -28,6 +28,8 @@ import src.models as models
 from src.env_utils import make_gym_env
 from src.utils import get_batch, log, create_buffers
 
+mp.set_sharing_strategy('file_system')
+
 PolicyNet = models.PolicyNet
 StateEmbeddingNet = models.StateEmbeddingNet
 ForwardDynamicsNet = models.ForwardDynamicsNet

--- a/test_model.py
+++ b/test_model.py
@@ -121,7 +121,7 @@ def run(flags):
     namefile = 'test__' + flags.algs + \
             '__' + flags.logdir.split(os.sep)[-3] + '-' + flags.logdir.split(os.sep)[-2] + \
             '__from_' + short_env_string(flags.from_env) + \
-            '__to_' + short_env_string(flags.to_env) + '_' + str(flags.count_reset_prob)
+            '__to_' + short_env_string(flags.to_env)
 
     print('... running: ' + namefile)
 


### PR DESCRIPTION
- Fixed a crash with Habitat environment in test script due to missing directory
- Fixed an issue where count_reset_prob is referenced, but is not tracked in the ArgumentParser by removing it
- Worked around a PyTorch memory bug (Ubuntu 21.10 + Driver Version: 495.29.05 + CUDA Version: 11.5 + torch version: 1.10.1+cu113)
  - Failed to allocate SHM despite plenty of available handles and many GiB of both system and GPU memory
  - Error message indicated an internal PyTorch bug, with instructions for filing a ticket